### PR TITLE
Trigger an 'input' event to ensure some web applications (eg. FastMail) correctly update

### DIFF
--- a/extension/page-prep.js
+++ b/extension/page-prep.js
@@ -46,10 +46,11 @@ chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
     }
     delete active_reqs[request.req];
     var ta = document.getElementById(request.id);
-    if (ta)
+    if (ta) {
       ta.value = request.text;
-    else
+    } else {
       alert('Unable to save changes for textarea ' + request.id);
+    }
   }
 });
 

--- a/extension/page-prep.js
+++ b/extension/page-prep.js
@@ -48,6 +48,8 @@ chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
     var ta = document.getElementById(request.id);
     if (ta) {
       ta.value = request.text;
+      // Trigger some web applications (eg. FastMail) to update internally
+      ta.dispatchEvent(new Event('input'));
     } else {
       alert('Unable to save changes for textarea ' + request.id);
     }


### PR DESCRIPTION
Closes #1.

Without this change, users must make some kind of manual change to the target element (eg. appending a newline and then removing it) otherwise some application's idea of what the target element contains is not updated.